### PR TITLE
Add worker test endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Initial architecture outline in `TargetPicture.md`.
+- Added technical analysis and optimization ideas.
+- Documented hardware and network optimizations.
+- Provided roadmap for phased implementation.
+- Implemented Cloudflare Worker manager with `/workers` CRUD API and tests.
+- Added connection state handling with `/connect`, `/disconnect`, `/status`,
+  and log endpoints.
+- Created initial VisionOS style UI skeleton with progress bar, node chain,
+  country dropdowns, and Logs/Settings modals.
+- Documented UI overview in README.
+- Added worker health checking and duplicate detection.
+- Backend now monitors local IP changes and logs them.
+- Added round-robin worker selection with direct exit fallback when none are active.
+- Worker endpoints persist to `workers.json` and reload on startup.
+- New `/torrc` endpoint validates and stores custom configuration.
+- Added `/config` endpoint to query and update OBFS4 and pre-warming settings persisted in `config.json`.
+- Connection and system logs now persist to rotating files under the config directory.
+- Log writer now flushes asynchronously to reduce I/O blocking.
+- `/connect` accepts JSON with `entry`, `middle`, `exit` and `cflist` fields.
+- Added `CircuitManager` with pre-warming of three circuits and rotation via `/connect` and `/new-circuit`.
+- Implemented in-memory DNS cache and automatic BBR(v2) enable on Linux.
+- Tor engine launches a tor process on connect and stops it on disconnect.
+- Status endpoint now returns connection progress; UI polls to update the progress bar.
+- Progress bar colour now reflects connection phase and worker health checks use the DNS cache.
+- Connection state now persisted in state.json and restored on startup.
+- Added graceful shutdown handling for server and background workers.
+- New /metrics endpoint exposes basic Prometheus-style metrics.
+- Tor engine reads `bridges.txt` when OBFS4 is enabled and passes bridges to tor.
+- `/status` includes a human-readable status message.
+- Added basic PWA support via `manifest.json` and `service-worker.js` in the UI.
+- Consolidated `TechnicalAnalysis.md` into `TargetPicture.md`.
+- Added experimental Tauri Mobile configuration and updated README with mobile build steps.
+- Added `/workers/test` endpoint to verify Cloudflare Worker URLs and test all configured workers.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,132 @@
 # Torwell84
+
+Torwell84 is a cross-platform Tor-VPN client powered by a Go backend and a Tauri + SvelteKit UI. It targets Windows, macOS, Linux, Android, iOS and Web with a VisionOS-inspired interface. The documentation lives in `TargetPicture.md`.
+
+See `Roadmap.md` for the planned development phases.
+
+## Build Instructions
+
+1. Install Go 1.22+ and Node.js.
+2. Build backend binaries:
+   ```sh
+   (cd backend && make all)
+   ```
+3. Setup UI dependencies:
+   ```sh
+   (cd ui && npm install)
+   ```
+4. Run Tauri development server:
+   ```sh
+   (cd ui && npm run dev)
+   ```
+
+The backend automatically monitors network IP changes and logs them so
+connections can be re-established. Configured Cloudflare Worker endpoints are
+persisted to disk and health checked every 30 seconds. When connecting,
+Torwell84 selects the next active Worker in a round-robin fashion and falls
+back to a direct exit if none are reachable. Circuits are kept pre-warmed using
+a `CircuitManager` so new connections establish quickly. OBFS4 and pre-warming
+preferences are saved in `config.json` and served through `/config`.
+DNS lookups are cached in memory for a short time; worker health checks reuse this cache to avoid repeated resolves. The server attempts to
+enable BBR(v2) congestion control on Linux. Connection and system logs are
+written asynchronously to rotating files under `logs/` inside this config
+directory.
+Connection state is persisted in `state.json` and restored on startup. The
+backend listens for `SIGINT`/`SIGTERM` to shut down the server and background
+goroutines gracefully.
+The `/connect` endpoint starts an embedded Tor process using any saved
+`torrc` configuration, while `/disconnect` stops it.
+
+### API Quick Reference
+
+The backend exposes a REST API on `127.0.0.1:9472` for controlling the Tor
+client and managing Cloudflare Workers:
+
+```text
+GET  /status  # returns {connected, progress, workers, config}
+POST /connect       {"entry":"DE","middle":"FR","exit":"US","cflist":["https://w.example"]}
+POST /disconnect
+POST /new-circuit
+POST /new-identity
+POST /torrc (multipart file "file")
+GET  /config
+POST /config       {"obfs4":true,"prewarm":true}
+GET  /logs/connection?level=debug
+GET  /logs/general
+GET  /workers
+POST /workers    {"URL":"https://example.workers.dev"}
+DELETE /workers  {"URL":"https://example.workers.dev"}
+POST /workers/test   {"URL":"https://example.workers.dev"} # empty body tests all
+GET  /metrics     # Prometheus style metrics
+```
+
+### UI Overview
+
+The SvelteKit/Tauri frontend displays a VisionOS style layout:
+
+- A progress bar at the top shows connection state from 0–100%, polling `/status` once per second. The bar starts purple while connecting, turns blue during handshake and becomes green once the circuit is ready.
+- A chain of five nodes (You, Entry, Middle, Exit, Cloudflare Worker) displays the
+  current circuit. Entry, Middle and Exit have country dropdowns based on the
+  static list in `TargetPicture.md`.
+- Below the chain a button row allows Connect/Disconnect, New Circuit/Identity,
+  and opens Logs and Settings modals.
+- The Logs modal lists connection and system logs with Clear and Close buttons.
+- Settings allow uploading a custom `torrc` verified through the `/torrc` endpoint (`tor --verify-config`), toggling OBFS4 and circuit
+  pre-warming, and managing Cloudflare Worker endpoints. Workers can be added
+  by entering the URL and hitting **Add**. Each row has **Test** and **Remove**
+  buttons, and a **Test All** button checks every configured Worker. OBFS4 and
+  pre-warming checkboxes immediately persist their state via the `/config`
+  endpoint.
+- When OBFS4 is enabled, tor reads bridges from `bridges.txt` inside the config directory.
+
+### Cross Compilation
+
+The backend Makefile builds optimized binaries for major platforms. Example for
+Apple M‑series with NEON acceleration:
+
+```sh
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -tags neon -o torwell84-darwin-arm64
+```
+
+AVX2 builds for x86_64 follow the same pattern using `-tags avx2`.
+
+Other targets can be built by setting the appropriate `GOOS` and `GOARCH` or
+using the provided Makefile:
+
+```sh
+# Linux and Windows examples
+GOOS=linux   GOARCH=amd64 CGO_ENABLED=1 go build -tags avx2 -o torwell84-linux-amd64
+GOOS=linux   GOARCH=arm64 CGO_ENABLED=1 go build -tags neon -o torwell84-linux-arm64
+GOOS=windows GOARCH=amd64 go build -o torwell84-windows-amd64.exe
+
+# Mobile targets (requires the mobile toolchain)
+GOOS=android GOARCH=arm64 go build -o torwell84-android-arm64
+GOOS=darwin  GOARCH=arm64 GOIOS=1 go build -o torwell84-ios-arm64
+
+# Or simply run
+make -C backend all
+```
+
+### Mobile Builds
+Tauri 2 provides experimental mobile support. After installing `@tauri-apps/cli` you can build and run the app on Android or iOS:
+
+```sh
+cd ui
+npx tauri mobile android build   # Android APK
+npx tauri mobile ios build       # iOS app
+```
+
+To compile both backend and UI in one step, run `./build.sh`. The script builds
+all backend binaries and packages the SvelteKit/Tauri frontend into `ui/build/`.
+
+### PWA
+To build the web target with offline support, `manifest.json` and `service-worker.js` are provided under `ui/static`. Modern browsers will automatically install the Service Worker after running `npm run build` inside `ui/` and serving the `build/` directory.
+
+### UI Tests
+
+End-to-end tests are implemented with Playwright. Install the browsers and run the suite via:
+
+```sh
+cd ui && npm install && npm test
+```
+

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,0 +1,30 @@
+# Torwell84 Roadmap
+
+This document outlines the recommended implementation phases for the project.
+
+## Phase 1 – Skeleton
+1. Create repository structure `/backend` and `/ui`.
+2. Stub Go REST API with `/status` and `/connect` endpoints.
+3. Basic Tauri + SvelteKit UI showing the node chain and buttons.
+4. Integrate Tor via go-tor with default config.
+
+## Phase 2 – Core Features
+1. Implement circuit manager with pre-warming and OBFS4.
+2. Add Cloudflare Worker management and failover logic.
+3. Wire up connection progress bar and logs modal.
+4. Enable custom `torrc` upload and validation.
+
+## Phase 3 – Optimization
+1. Compile binaries with AVX2/NEON flags.
+2. Add in-memory caching for circuits and DNS responses.
+3. Enable BBRv2 congestion control where available.
+4. Implement GPU-accelerated transitions and 60 FPS rendering.
+
+## Phase 4 – Mobile and Web
+1. Setup Tauri Mobile alpha targets for Android and iOS. **(done)**
+2. Configure PWA build and service worker for web.
+3. Validate performance goals on all platforms.
+
+## Ongoing
+- Maintain `CHANGELOG.md` for every feature.
+- Update documentation when APIs or UI elements change.

--- a/TODO123.md
+++ b/TODO123.md
@@ -1,0 +1,31 @@
+# Implementation Plan
+
+This file lists the remaining tasks to complete **Torwell84**. Follow the steps sequentially.
+
+## 1. Backend Enhancements
+- [x] Integrate the Tor engine with real tor binary and obfs4 bridges.
+- [x] Persist connection state and worker list across restarts.
+- [x] Implement automatic circuit rotation on `/new-circuit`.
+- [x] Add graceful shutdown handling for all goroutines.
+- [x] Expose metrics endpoint for debugging (optional).
+
+## 2. Frontend Improvements
+- [x] Finalize VisionOS style with GPU acceleration and animations.
+- [x] Implement dropdowns for country selection as defined in `TargetPicture.md`.
+- [x] Add connection progress color changes and detailed status messages.
+- [x] Enable management of Cloudflare Worker URLs from the settings modal.
+- [x] Add Playwright tests for main user flows.
+
+## 3. Mobile and Web Targets
+- [x] Configure Tauri Mobile for Android and iOS builds.
+- [x] Add service worker and PWA manifest for the web target.
+
+## 4. Performance and Hardware Optimizations
+- [x] Build binaries with AVX2/NEON flags using the Makefile.
+- [x] Enable BBRv2 automatically on Linux systems.
+- [x] Introduce in-memory DNS and circuit caches.
+
+## 5. Documentation and Cleanup
+- [x] Update README with exact build commands for all platforms.
+- [x] Keep CHANGELOG up to date for each feature.
+- [x] Review and expand unit tests to cover new endpoints and functionality.

--- a/TargetPicture.md
+++ b/TargetPicture.md
@@ -1,0 +1,190 @@
+# Project Torwell84
+
+## Overview
+Torwell84 is a cross-platform Tor-VPN client combining a Go backend with a Tauri + SvelteKit frontend. The goal is to deliver a single binary per platform with a modern VisionOS "Liquid Glass" user interface and full GPU acceleration via WGPU/Metal/Vulkan. Supported targets are Windows 10+, macOS 12+ (x86_64 and arm64/Neon), Linux (glibc 2.31+), Android 10+, iOS 15+, and the Web via PWA.
+
+### Why Tauri + SvelteKit?
+* **Small footprint** – Tauri bundles only a lightweight Rust core and a WebView, resulting in binaries around a few megabytes instead of full Electron size.
+* **GPU acceleration** – WGPU allows hardware-accelerated rendering via Metal, Vulkan or DirectX, enabling the VisionOS "Liquid Glass" style at 60 FPS.
+* **Official integration guides** – Tauri provides step‑by‑step docs for SvelteKit and ships mobile wrappers starting with v2, letting the same codebase target Android and iOS.
+* **Web-first** – SvelteKit builds to a performant PWA for the web target without additional tooling.
+
+## Architecture
+### Backend (`torwell84/backend`)
+- **Language:** Go 1.22+
+- **Tor integration:** embed Tor using Go bindings such as `go-tor`. OBFS4 bridges are enabled by default. A custom `torrc` can be uploaded through the UI. Bridges are read from `bridges.txt` in the config directory if present.
+- **Cross compilation:** static binaries for Windows, Linux and macOS are produced via the Makefile. Mobile builds require the Go mobile toolchain.
+  Example commands:
+  ```sh
+  # macOS Apple Silicon
+  GOOS=darwin  GOARCH=arm64 CGO_ENABLED=1 go build -tags neon -o torwell84-darwin-arm64
+  # Windows
+  GOOS=windows GOARCH=amd64 go build -o torwell84-windows-amd64.exe
+  # Linux AMD64
+  GOOS=linux   GOARCH=amd64 CGO_ENABLED=1 go build -tags avx2 -o torwell84-linux-amd64
+  # Android/iOS
+  GOOS=android GOARCH=arm64 go build -o torwell84-android-arm64
+  GOOS=darwin  GOARCH=arm64 GOIOS=1 go build -o torwell84-ios-arm64
+  ```
+  Neon intrinsics may be enabled via `// #cgo CFLAGS: -mfpu=neon` on ARM builds while AVX2 is selected with `-tags avx2` on x86_64.
+- **REST API** served on `127.0.0.1:9472`:
+  - `GET  /status` – returns `{connected, progress, workers, config}`
+  - `POST /connect` with JSON `{entry, middle, exit, cflist[]}` – launches the embedded Tor process
+  - `POST /disconnect` – stops the Tor process
+  - `POST /new-circuit`
+  - `POST /new-identity`
+  - `POST /torrc` – upload custom configuration
+  - `GET  /config` – retrieve current OBFS4 and pre-warming settings
+  - `POST /config` – update settings `{obfs4, prewarm}`
+  - `GET  /logs/connection?level=debug`
+  - `GET  /logs/general`
+  - `GET  /workers` – list configured Cloudflare Workers
+  - `POST /workers` – add a new Worker `{URL}` (health checked before accepting)
+  - `DELETE /workers` – remove Worker `{URL}`
+  - `POST /workers/test` – test a single Worker `{URL}` or all when body is empty
+- **Circuit manager**
+  - Keeps three circuits pre-warmed at all times.
+  - Stores the last healthy Cloudflare Worker endpoint and runs a health check every 30 s (requests `/.well-known/healthz`).
+  - Uses round-robin selection across healthy Workers and falls back to direct Tor exit if none respond.
+- **Logging**
+  - Rotating JSON log files under `$APPDATA/torwell84/logs` (or platform equivalent).
+  - Connection logs at DEBUG level, general logs at INFO level.
+
+### Backend Modules
+The backend is organised into loosely coupled modules so features remain easy to
+maintain and extend:
+
+| Module          | Purpose                                                        |
+|-----------------|----------------------------------------------------------------|
+| `torengine`     | Embeds the Tor daemon via Go bindings and exposes a control API |
+| `api/http`      | Implements the REST endpoints listed above                      |
+| `circuit-manager` | Handles pre‑warming, country selection and worker failover    |
+| `proxy-cf`      | Optional HTTPS forwarder to the Cloudflare Worker endpoints    |
+| `logging`       | Collects connection and general logs with rotation to files under the config directory |
+
+
+### Frontend (`torwell84/ui`)
+- **Framework:** Tauri 2 with SvelteKit and TypeScript.
+ - **Style:** VisionOS “Liquid Glass” aesthetic implemented with a reusable `glass` CSS class. Animations rely on GPU-accelerated `transform` transitions to maintain 60 FPS.
+- **Layout:**
+  1. **Top progress bar**
+     - Tor-style bar from 0–100 % with color phases (connecting, handshaking, establishing circuit, ready).
+     - Polls `/status` every second to update progress in real time.
+  2. **Node chain** (five icons in a row)
+     - **You**: fixed label "U" with local flag.
+     - **Entry node**
+     - **Middle node**
+     - **Exit node**
+     - **Cloudflare Worker** (greyed out when no Worker configured).
+     - Each node shows Tor node name, country flag, and IP address beneath the icon. The three Tor nodes have a **country dropdown** above them for selecting the desired country.
+  3. **Button row** beneath the chain
+     - Connect / Disconnect (toggle)
+     - New Circuit / New Identity (toggles based on state)
+     - Logs (opens modal)
+     - Settings (opens modal)
+  4. **Logs modal**
+     - Tabs: *Connection*, *System*, *All*.
+     - Each tab lists logs with `Copy` and `Clear` buttons.
+     - Logs are cleared on application start.
+  5. **Settings modal**
+     - Upload custom `torrc` file; validate with `tor --verify-config` before applying.
+     - Toggle OBFS4 bridges (default **ON**).
+     - Toggle circuit pre-warming (default **ON**).
+    - Manage Cloudflare Worker list: add new endpoint, test it via `/.well-known/healthz`, remove existing ones. Working endpoints are persisted in `workers.json` and selected in round-robin order.
+    - OBFS4 and pre-warming toggles are stored in `config.json` alongside the worker file.
+
+#### Additional UI details
+* **Progress bar colours**: purple while connecting, blue during handshake and green once the circuit is ready.
+* **Icons**: a laptop for "You", onion symbols for the Tor nodes and the Cloudflare logo for the Worker.
+* **Logs modal**: opens in a floating "glass" pane with tabs along the top. Each tab shows a scrollable text area and `Copy`/`Clear` buttons on the bottom right.
+* **Settings modal**: contains checkboxes and toggles styled as iOS switches. The Cloudflare Worker table lists the URL and last health check result with `Add`, `Test`, `Remove` and a global `Test All` button.
+* **Responsive layout**: on mobile the node chain stacks vertically and the button row becomes a column to remain finger-friendly.
+- **Static country list** for dropdowns (in this order):
+  `["Deutschland","Frankreich","Belgien","Schweiz","Liechtenstein","Luxemburg","Österreich","Spanien","Italien","Portugal","Russland","Rumänien","Türkei","UK","USA","Kanada","Mexiko","Brasilien","Argentinien","Japan","China","Antarktis"]`
+- **Adaptive design**: UI scales for desktop and mobile; touch input supported on mobile.
+
+### Cloudflare Worker Proxy
+- Optional fourth hop after the Tor exit node. Traffic is forwarded through user-supplied HTTPS Cloudflare Worker endpoints.
+- Health checks every 30s. The backend rotates through healthy Workers in round-robin order. If none respond, traffic is sent directly through the Tor exit node.
+
+### Hardware and Network Optimization
+- **CPU features:** binaries include AVX2 on x86_64 and NEON on ARM64 to accelerate cryptography and compression.
+- **GPU acceleration:** WGPU uses Metal on macOS (including Apple M-series), Vulkan on Windows/Linux, and OpenGL ES on mobile devices to maintain smooth 60 FPS.
+- **TCP congestion control:** the backend attempts to enable BBRv2 on Linux at startup to improve throughput on high latency links.
+- **In-memory cache:** recent circuit descriptors and DNS responses are stored in memory via a `dnsCache` module to minimize latency.
+  Worker health checks reuse this cache to reduce DNS lookups.
+- **IP monitoring:** the backend watches for local IP changes and logs them so circuits can be re-established seamlessly.
+- **Encryption:** all proxy connections enforce TLS 1.3 with ChaCha20-Poly1305 preferred, falling back to AES-GCM.
+
+### Mobile and Web
+- Tauri Mobile alpha wrapper for Android and iOS using the same SvelteKit codebase.
+- When built for Web, served as a PWA with a Service Worker for offline caching.
+
+### Performance Targets
+- Backend API latency < 100 ms under 1k concurrent connections.
+- Frontend animations remain at 60 FPS with TTI < 50 ms on modern hardware.
+
+## Deliverables
+1. `/backend` – Go sources with a Makefile (`make all` cross-compiles the static binaries).
+2. `/ui` – SvelteKit project including Tauri configuration for desktop, mobile and web.
+3. `build.sh` – one-liner script that compiles the project for all targets and places outputs into platform folders.
+4. `README.md` – instructions on building, running, and adding Cloudflare Worker endpoints.
+5. `TargetPicture.md` – this architecture document.
+
+## Build & Deployment
+1. Install Go 1.22+ and Node.js.
+2. Run `make -C backend all` to build backend binaries for desktop targets.
+3. Inside `ui/`, execute `npm install` followed by `npm run build` to compile the SvelteKit frontend.
+4. Execute `./build.sh` to produce release artifacts that combine backend and UI into platform folders.
+5. For mobile builds, install the Go mobile toolchain and use the commands shown in the cross compilation section.
+
+## Additional Notes
+- Cloudflare Worker section is disabled (grey) until at least one Worker is configured.
+- Logs start empty on each launch and are viewable through the Logs modal.
+- Name “Torwell84” nods to a cyberpunk twist on *Orwell 1984*.
+- Sample cross‑compile for macOS on Apple Silicon:
+  ```sh
+  GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -tags "neon" -o torwell84-darwin-arm64
+  ```
+
+## Technical Analysis and Suggested Improvements
+
+
+This document lists possible optimizations and enhancements for **Torwell84** based on the current architecture.
+
+## 1. Backend Efficiency
+- **Go modules**: use minimal modules and build tags for each platform to avoid unused code in the final binary.
+- **Connection pooling**: maintain persistent HTTP connections where possible to reduce latency for repeated REST calls.
+- **Asynchronous logging**: buffer log writes and flush in the background to reduce blocking during high load. This is now implemented via a goroutine in `logWriter`.
+- **Torrc validation**: when a custom `torrc` is uploaded, run `tor --verify-config` and return errors before restarting Tor. This prevents invalid settings from breaking the connection.
+- **Config persistence**: expose `/config` endpoints storing OBFS4 and pre-warming flags in `config.json` so they survive restarts.
+- **Embedded Tor process**: the `TorEngine` module launches the system `tor` binary on `/connect` and stops it on `/disconnect`.
+
+## 2. Frontend Enhancements
+- **State management**: leverage Svelte stores for reactive updates and to keep UI state minimal.
+- **Lazy loading**: load heavy components (e.g., logs modal) only when needed to keep initial startup quick.
+- **GPU usage**: limit overdraw and keep the DOM hierarchy shallow so that the VisionOS effects remain smooth on weaker devices.
+
+## 3. Cloudflare Worker Management
+- **Automated failover**: already planned, but could also include tracking response times and preferring the fastest worker.
+- **Endpoint import/export**: allow users to export their configured worker list and share it across devices.
+
+## 4. Additional Features
+- **Integrated updates**: optional auto-updater fetching new binaries from a signed release feed.
+- **Tray icon**: small helper process for quick connect/disconnect without opening the full UI.
+- **Dark/light theme**: switchable VisionOS-style themes for better accessibility.
+
+## 5. Hardware and Network Optimization
+- **AVX2/NEON builds**: compile with architecture-specific flags for better crypto throughput.
+- **BBRv2**: the server now attempts to enable the BBRv2 congestion control algorithm on Linux at startup.
+- **In-memory caching**: a `dnsCache` module keeps DNS lookups in RAM for quick reuse.
+- **TLS 1.3**: use modern ciphers (ChaCha20-Poly1305/AES-GCM) for proxy connections.
+- **IP monitoring**: detect changes of local interfaces and gracefully reconnect if needed.
+
+## 6. Security Considerations
+- **Sandboxing**: run the embedded Tor process with restricted permissions and separate data directories per platform.
+- **Code signing**: sign all release binaries to prevent tampering.
+- **Network hardening**: verify TLS certificates when talking to Cloudflare Worker endpoints and use pinned keys if possible.
+
+These points are optional extensions on top of the current design in `TargetPicture.md` and can help improve usability, performance, and security.
+

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,21 @@
+BINS = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64
+
+all: $(BINS)
+
+linux-amd64:
+GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags avx2 -o build/torwell84-linux-amd64
+
+linux-arm64:
+GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -tags neon -o build/torwell84-linux-arm64
+
+darwin-amd64:
+GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -tags avx2 -o build/torwell84-darwin-amd64
+
+darwin-arm64:
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -tags neon -o build/torwell84-darwin-arm64
+
+windows-amd64:
+GOOS=windows GOARCH=amd64 go build -o build/torwell84-windows-amd64.exe
+
+clean:
+rm -rf build

--- a/backend/circuit.go
+++ b/backend/circuit.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Circuit represents a single Tor circuit (mock).
+type Circuit struct {
+	ID int
+}
+
+// CircuitManager keeps a pool of pre-warmed circuits.
+type CircuitManager struct {
+	mu       sync.Mutex
+	circuits []Circuit
+	size     int
+	nextID   int
+}
+
+// NewCircuitManager creates a manager that keeps n circuits pre-warmed.
+func NewCircuitManager(n int) *CircuitManager {
+	cm := &CircuitManager{size: n}
+	cm.prewarm()
+	return cm
+}
+
+// prewarm ensures the pool has the desired number of circuits.
+func (cm *CircuitManager) prewarm() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	for len(cm.circuits) < cm.size {
+		cm.nextID++
+		cm.circuits = append(cm.circuits, Circuit{ID: cm.nextID})
+	}
+}
+
+// Next returns the next circuit from the pool and triggers pre-warming of a new one.
+func (cm *CircuitManager) Next() Circuit {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if len(cm.circuits) == 0 {
+		cm.nextID++
+		return Circuit{ID: cm.nextID}
+	}
+	c := cm.circuits[0]
+	cm.circuits = cm.circuits[1:]
+	cm.nextID++
+	cm.circuits = append(cm.circuits, Circuit{ID: cm.nextID})
+	return c
+}
+
+// Start periodically ensures circuits remain pre-warmed.
+func (cm *CircuitManager) Start(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cm.prewarm()
+			}
+		}
+	}()
+}

--- a/backend/config.go
+++ b/backend/config.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Config holds user adjustable settings.
+type Config struct {
+	OBFS4   bool `json:"obfs4"`
+	PreWarm bool `json:"prewarm"`
+}
+
+var (
+	cfg   Config
+	cfgMu sync.RWMutex
+)
+
+// loadConfig reads configuration from disk.
+func loadConfig(dir string) error {
+	cfgMu.Lock()
+	defer cfgMu.Unlock()
+	path := filepath.Join(dir, "config.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			cfg = Config{OBFS4: true, PreWarm: true}
+			return nil
+		}
+		return err
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// saveConfig writes the current config to disk.
+func saveConfig(dir string) error {
+	cfgMu.RLock()
+	defer cfgMu.RUnlock()
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "config.json")
+	return os.WriteFile(path, b, 0600)
+}
+
+// getConfig returns a copy of current configuration.
+func getConfig() Config {
+	cfgMu.RLock()
+	defer cfgMu.RUnlock()
+	return cfg
+}
+
+// updateConfig merges new settings into the current config.
+func updateConfig(c Config) {
+	cfgMu.Lock()
+	defer cfgMu.Unlock()
+	if c.OBFS4 != cfg.OBFS4 {
+		cfg.OBFS4 = c.OBFS4
+	}
+	if c.PreWarm != cfg.PreWarm {
+		cfg.PreWarm = c.PreWarm
+	}
+}

--- a/backend/dnscache.go
+++ b/backend/dnscache.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+)
+
+// dnsCache caches DNS lookups for a short period.
+type dnsCache struct {
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+	ttl   time.Duration
+	r     *net.Resolver
+}
+
+type cacheEntry struct {
+	addrs  []string
+	expiry time.Time
+}
+
+func newDNSCache(ttl time.Duration) *dnsCache {
+	return &dnsCache{cache: make(map[string]cacheEntry), ttl: ttl, r: net.DefaultResolver}
+}
+
+func (d *dnsCache) LookupHost(host string) ([]string, error) {
+	d.mu.Lock()
+	if e, ok := d.cache[host]; ok && time.Now().Before(e.expiry) {
+		addrs := make([]string, len(e.addrs))
+		copy(addrs, e.addrs)
+		d.mu.Unlock()
+		return addrs, nil
+	}
+	d.mu.Unlock()
+
+	addrs, err := d.r.LookupHost(context.Background(), host)
+	if err != nil {
+		return nil, err
+	}
+
+	d.mu.Lock()
+	d.cache[host] = cacheEntry{addrs: addrs, expiry: time.Now().Add(d.ttl)}
+	d.mu.Unlock()
+	return addrs, nil
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,7 @@
+module torwell84/backend
+
+go 1.22
+
+require (
+)
+

--- a/backend/log.go
+++ b/backend/log.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// logWriter writes log entries to a file with simple size-based rotation.
+type logWriter struct {
+	mu   sync.Mutex
+	file *os.File
+	size int64
+	dir  string
+	base string
+	ch   chan string
+	wg   sync.WaitGroup
+}
+
+func newLogWriter(dir, base string) (*logWriter, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+	lw := &logWriter{dir: dir, base: base, ch: make(chan string, 100)}
+	if err := lw.open(); err != nil {
+		return nil, err
+	}
+	lw.wg.Add(1)
+	go lw.loop()
+	return lw, nil
+}
+
+func (lw *logWriter) loop() {
+	defer lw.wg.Done()
+	for entry := range lw.ch {
+		lw.write(entry)
+	}
+}
+
+func (lw *logWriter) write(entry string) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	if lw.file == nil {
+		if err := lw.open(); err != nil {
+			return
+		}
+	}
+	n, _ := lw.file.WriteString(entry + "\n")
+	lw.size += int64(n)
+	if lw.size > 1<<20 { // 1MB
+		_ = lw.rotate()
+	}
+}
+
+func (lw *logWriter) open() error {
+	path := filepath.Join(lw.dir, lw.base+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	lw.file = f
+	info, err := f.Stat()
+	if err == nil {
+		lw.size = info.Size()
+	}
+	return nil
+}
+
+func (lw *logWriter) rotate() error {
+	lw.file.Close()
+	ts := time.Now().Format("20060102-150405")
+	old := filepath.Join(lw.dir, fmt.Sprintf("%s-%s.log", lw.base, ts))
+	os.Rename(filepath.Join(lw.dir, lw.base+".log"), old)
+	lw.size = 0
+	return lw.open()
+}
+
+func (lw *logWriter) Write(entry string) {
+	select {
+	case lw.ch <- entry:
+	default:
+		lw.write(entry)
+	}
+}
+
+// Close flushes pending log entries and closes the file.
+func (lw *logWriter) Close() {
+	close(lw.ch)
+	lw.wg.Wait()
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	if lw.file != nil {
+		lw.file.Close()
+		lw.file = nil
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	dnsC           = newDNSCache(5 * time.Minute)
+	wm             = NewWorkerManager(dnsC)
+	cm             = NewCircuitManager(3)
+	progress       int
+	progMu         sync.RWMutex
+	statusMsg      string = "disconnected"
+	statusMu       sync.RWMutex
+	progressCancel context.CancelFunc
+	connLogs       []string
+	generalLogs    []string
+	connLogger     *logWriter
+	genLogger      *logWriter
+	lastIP         string
+	cfgDir         string
+)
+
+func setProgress(p int) {
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	progMu.Lock()
+	progress = p
+	progMu.Unlock()
+}
+
+func setStatus(s string) {
+	statusMu.Lock()
+	statusMsg = s
+	statusMu.Unlock()
+}
+
+func getStatus() string {
+	statusMu.RLock()
+	defer statusMu.RUnlock()
+	return statusMsg
+}
+
+func getProgress() int {
+	progMu.RLock()
+	defer progMu.RUnlock()
+	return progress
+}
+
+func startProgress() {
+	if progressCancel != nil {
+		progressCancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	progressCancel = cancel
+	setProgress(0)
+	go func() {
+		steps := []struct {
+			p int
+			s string
+		}{{10, "connecting"}, {30, "handshake"}, {60, "establishing"}, {80, "almost ready"}, {100, "ready"}}
+		for _, step := range steps {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(1 * time.Second):
+				setProgress(step.p)
+				setStatus(step.s)
+			}
+		}
+	}()
+}
+
+func stopProgress() {
+	if progressCancel != nil {
+		progressCancel()
+		progressCancel = nil
+	}
+	setProgress(0)
+	setStatus("disconnected")
+}
+
+func configDir() string {
+	if d := os.Getenv("TORWELL84_CONFIG"); d != "" {
+		return d
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "."
+	}
+	return filepath.Join(dir, "torwell84")
+}
+
+type Status struct {
+	Connected bool     `json:"connected"`
+	Progress  int      `json:"progress"`
+	Status    string   `json:"status"`
+	Workers   []Worker `json:"workers"`
+	Config    Config   `json:"config"`
+}
+
+func addLog(dst *[]string, lw *logWriter, msg string) {
+	entry := time.Now().Format(time.RFC3339) + " " + msg
+	*dst = append(*dst, entry)
+	if len(*dst) > 1000 {
+		*dst = (*dst)[len(*dst)-1000:]
+	}
+	if lw != nil {
+		lw.Write(entry)
+	}
+}
+
+// monitorIP periodically checks the primary IP address and logs changes.
+func monitorIP(ctx context.Context, interval time.Duration) {
+	ip := getLocalIP()
+	lastIP = ip
+	addLog(&generalLogs, genLogger, "initial ip "+ip)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			current := getLocalIP()
+			if current != lastIP {
+				addLog(&generalLogs, genLogger, "ip changed to "+current)
+				lastIP = current
+			}
+		}
+	}
+}
+
+func getLocalIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
+}
+
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// handleTorrc verifies and stores an uploaded torrc file.
+func handleTorrc(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "missing file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	tmp, err := os.CreateTemp("", "torrc")
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := io.Copy(tmp, file); err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	tmp.Close()
+
+	tor := os.Getenv("TOR_BINARY")
+	if tor == "" {
+		tor = "tor"
+	}
+	cmd := exec.Command(tor, "-f", tmp.Name(), "--verify-config")
+	if err := cmd.Run(); err != nil {
+		http.Error(w, "invalid torrc", http.StatusBadRequest)
+		return
+	}
+
+	dst := filepath.Join(cfgDir, "torrc")
+	if err := os.Rename(tmp.Name(), dst); err != nil {
+		http.Error(w, "save error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func newServer() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Status{Connected: isConnected(), Progress: getProgress(), Status: getStatus(), Workers: wm.List(), Config: getConfig()})
+	})
+
+	mux.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Entry  string   `json:"entry"`
+			Middle string   `json:"middle"`
+			Exit   string   `json:"exit"`
+			CFList []string `json:"cflist"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		if err := engine.Start(cfgDir); err != nil {
+			http.Error(w, "tor start failed", http.StatusInternalServerError)
+			return
+		}
+		setConnected(true)
+		setStatus("connecting")
+		_ = saveState(cfgDir)
+		startProgress()
+		c := cm.Next()
+		if url, ok := wm.Next(); ok {
+			addLog(&connLogs, connLogger, "circuit "+fmt.Sprint(c.ID)+" via "+url)
+			addLog(&generalLogs, genLogger, "using worker "+url)
+		} else {
+			addLog(&connLogs, connLogger, fmt.Sprintf("circuit %d direct", c.ID))
+			addLog(&generalLogs, genLogger, "no active worker; direct exit")
+		}
+		addLog(&generalLogs, genLogger, "circuit entry="+req.Entry+" middle="+req.Middle+" exit="+req.Exit)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/disconnect", func(w http.ResponseWriter, r *http.Request) {
+		_ = engine.Stop()
+		stopProgress()
+		setConnected(false)
+		setStatus("disconnected")
+		_ = saveState(cfgDir)
+		addLog(&connLogs, connLogger, "disconnected")
+		addLog(&generalLogs, genLogger, "disconnected")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/new-circuit", func(w http.ResponseWriter, r *http.Request) {
+		c := cm.Next()
+		addLog(&generalLogs, genLogger, fmt.Sprintf("rotated to circuit %d", c.ID))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/new-identity", func(w http.ResponseWriter, r *http.Request) {
+		addLog(&generalLogs, genLogger, "new identity requested")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/workers", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(wm.List())
+		case http.MethodPost:
+			var req struct{ URL string }
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if err := wm.Add(req.URL); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodDelete:
+			var req struct{ URL string }
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			wm.Remove(req.URL)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/workers/test", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct{ URL string }
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.URL == "" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(wm.TestAll())
+			return
+		}
+		if err := wm.Test(req.URL); err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(getConfig())
+		case http.MethodPost:
+			var c Config
+			if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			updateConfig(c)
+			if err := saveConfig(cfgDir); err != nil {
+				http.Error(w, "save error", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/logs/connection", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.URL.Query().Get("level") // level currently unused
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(connLogs)
+	})
+
+	mux.HandleFunc("/logs/general", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(generalLogs)
+	})
+
+	mux.HandleFunc("/torrc", handleTorrc)
+
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintf(w, "torwell_connected %d\n", boolInt(isConnected()))
+		fmt.Fprintf(w, "torwell_progress %d\n", getProgress())
+		fmt.Fprintf(w, "torwell_workers %d\n", len(wm.List()))
+	})
+
+	return mux
+}
+
+func main() {
+	cfgDir = configDir()
+	os.MkdirAll(cfgDir, 0700)
+	logDir := filepath.Join(cfgDir, "logs")
+	var err error
+	connLogger, err = newLogWriter(logDir, "connection")
+	if err != nil {
+		log.Printf("log writer error: %v", err)
+	}
+	genLogger, err = newLogWriter(logDir, "general")
+	if err != nil {
+		log.Printf("log writer error: %v", err)
+	}
+	wm.Load(filepath.Join(cfgDir, "workers.json"))
+	loadConfig(cfgDir)
+	loadState(cfgDir)
+	enableBBRv2()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	wm.StartHealthChecker(ctx, 30*time.Second)
+	go monitorIP(ctx, 10*time.Second)
+	cm.Start(ctx, 30*time.Second)
+
+	addr := "127.0.0.1:9472"
+	srv := &http.Server{Addr: addr, Handler: newServer()}
+	go func() {
+		log.Printf("starting server on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+	<-ctx.Done()
+	log.Println("shutting down")
+	srv.Shutdown(context.Background())
+	engine.Stop()
+	connLogger.Close()
+	genLogger.Close()
+}

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,0 +1,410 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatus(t *testing.T) {
+	wm = NewWorkerManager(nil)
+	cfg = Config{OBFS4: true, PreWarm: true}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Status{Connected: false, Progress: 0, Status: "", Workers: wm.List(), Config: getConfig()})
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/status", nil)
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestWorkerCRUD(t *testing.T) {
+	wm = NewWorkerManager(nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/workers", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(wm.List())
+		case http.MethodPost:
+			var req struct{ URL string }
+			json.NewDecoder(r.Body).Decode(&req)
+			_ = wm.Add(req.URL)
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodDelete:
+			var req struct{ URL string }
+			json.NewDecoder(r.Body).Decode(&req)
+			wm.Remove(req.URL)
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	// Add worker
+	postReq := httptest.NewRequest(http.MethodPost, "/workers", strings.NewReader(`{"URL":"`+srv.URL+`"}`))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, postReq)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	// List workers
+	getReq := httptest.NewRequest(http.MethodGet, "/workers", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, getReq)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got []Worker
+	json.NewDecoder(w.Body).Decode(&got)
+	if len(got) != 1 || got[0].URL != srv.URL {
+		t.Fatalf("unexpected workers list: %v", got)
+	}
+}
+
+func TestWorkerHealthCheck(t *testing.T) {
+	// healthy server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wm = NewWorkerManager(nil)
+	if err := wm.Add(srv.URL); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if len(wm.List()) != 1 || !wm.List()[0].Active {
+		t.Fatal("worker not active")
+	}
+
+	// make server unhealthy
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	wm.CheckAll()
+	if wm.List()[0].Active {
+		t.Fatal("expected inactive worker")
+	}
+}
+
+func TestWorkerNext(t *testing.T) {
+	// two healthy servers
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv1.Close()
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv2.Close()
+
+	wm = NewWorkerManager(nil)
+	if err := wm.Add(srv1.URL); err != nil {
+		t.Fatalf("add1: %v", err)
+	}
+	if err := wm.Add(srv2.URL); err != nil {
+		t.Fatalf("add2: %v", err)
+	}
+
+	url, ok := wm.Next()
+	if !ok || url != srv1.URL {
+		t.Fatalf("expected %s, got %s", srv1.URL, url)
+	}
+	url, ok = wm.Next()
+	if !ok || url != srv2.URL {
+		t.Fatalf("expected %s, got %s", srv2.URL, url)
+	}
+
+	// make first server unhealthy and check failover
+	srv1.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	wm.CheckAll()
+	url, ok = wm.Next()
+	if !ok || url != srv2.URL {
+		t.Fatalf("expected failover to %s, got %s", srv2.URL, url)
+	}
+}
+
+func TestWorkerPersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workers.json")
+	wm = NewWorkerManager(nil)
+	if err := wm.Load(path); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	if err := wm.Add(srv.URL); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	wm2 := NewWorkerManager(nil)
+	if err := wm2.Load(path); err != nil {
+		t.Fatalf("load2: %v", err)
+	}
+	if len(wm2.List()) != 1 || wm2.List()[0].URL != srv.URL {
+		t.Fatalf("persistence failed: %v", wm2.List())
+	}
+}
+
+func TestWorkerTestEndpoint(t *testing.T) {
+	wm = NewWorkerManager(nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	handler := newServer()
+
+	// test single URL
+	req := httptest.NewRequest(http.MethodPost, "/workers/test", strings.NewReader(`{"URL":"`+srv.URL+`"}`))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("single test failed: %d", w.Code)
+	}
+
+	// add worker and make unhealthy
+	_ = wm.Add(srv.URL)
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	req = httptest.NewRequest(http.MethodPost, "/workers/test", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("test all failed: %d", w.Code)
+	}
+	var res map[string]bool
+	json.NewDecoder(w.Body).Decode(&res)
+	if ok, found := res[srv.URL]; !found || ok {
+		t.Fatalf("expected unhealthy result, got %v", res)
+	}
+}
+
+func TestTorrcUpload(t *testing.T) {
+	dir := t.TempDir()
+	os.Setenv("TORWELL84_CONFIG", dir)
+	defer os.Unsetenv("TORWELL84_CONFIG")
+	cfgDir = dir
+
+	tor := filepath.Join(dir, "tor")
+	os.WriteFile(tor, []byte("#!/bin/sh\nexit 0"), 0755)
+	os.Setenv("TOR_BINARY", tor)
+	defer os.Unsetenv("TOR_BINARY")
+
+	handler := newServer()
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	fw, _ := w.CreateFormFile("file", "torrc")
+	fw.Write([]byte("SocksPort 9050"))
+	w.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/torrc", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("upload failed: %d", resp.Code)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "torrc")); err != nil {
+		t.Fatalf("torrc not saved: %v", err)
+	}
+}
+
+func TestConfigEndpoints(t *testing.T) {
+	dir := t.TempDir()
+	os.Setenv("TORWELL84_CONFIG", dir)
+	defer os.Unsetenv("TORWELL84_CONFIG")
+	cfgDir = dir
+	loadConfig(dir)
+
+	handler := newServer()
+
+	// get default config
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get config failed: %d", w.Code)
+	}
+	var c Config
+	json.NewDecoder(w.Body).Decode(&c)
+	if !c.OBFS4 || !c.PreWarm {
+		t.Fatalf("unexpected default config %+v", c)
+	}
+
+	// update config
+	body := strings.NewReader(`{"obfs4":false}`)
+	req = httptest.NewRequest(http.MethodPost, "/config", body)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("post config failed: %d", w.Code)
+	}
+
+	// verify saved value
+	req = httptest.NewRequest(http.MethodGet, "/config", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	json.NewDecoder(w.Body).Decode(&c)
+	if c.OBFS4 != false {
+		t.Fatalf("config not updated: %+v", c)
+	}
+}
+
+func TestConnectAndLogs(t *testing.T) {
+	wm = NewWorkerManager(nil)
+	setConnected(false)
+	connLogs = nil
+	generalLogs = nil
+
+	connLogger, _ = newLogWriter(t.TempDir(), "conn")
+	genLogger, _ = newLogWriter(t.TempDir(), "gen")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {
+		setConnected(true)
+		addLog(&connLogs, connLogger, "connected")
+		addLog(&generalLogs, genLogger, "connected")
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(Status{Connected: isConnected(), Progress: getProgress(), Status: getStatus(), Workers: wm.List()})
+	})
+	mux.HandleFunc("/logs/general", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(generalLogs)
+	})
+
+	// connect
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/connect", nil)
+	mux.ServeHTTP(w, req)
+	if !isConnected() {
+		t.Fatal("expected connected state")
+	}
+
+	// status
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/status", nil)
+	mux.ServeHTTP(w, req)
+	var st Status
+	json.NewDecoder(w.Body).Decode(&st)
+	if !st.Connected {
+		t.Fatal("status not connected")
+	}
+
+	// logs
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/logs/general", nil)
+	mux.ServeHTTP(w, req)
+	var logs []string
+	json.NewDecoder(w.Body).Decode(&logs)
+	if len(logs) == 0 {
+		t.Fatal("expected logs")
+	}
+	connLogger.Close()
+	genLogger.Close()
+}
+
+func TestLogWriter(t *testing.T) {
+	dir := t.TempDir()
+	lw, err := newLogWriter(dir, "test")
+	if err != nil {
+		t.Fatalf("newLogWriter: %v", err)
+	}
+	lw.Write("one")
+	lw.Write("two")
+	lw.Close()
+	data, err := os.ReadFile(filepath.Join(dir, "test.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !bytes.Contains(data, []byte("one")) || !bytes.Contains(data, []byte("two")) {
+		t.Fatalf("log entries missing: %s", data)
+	}
+}
+
+func TestCircuitManager(t *testing.T) {
+	cm := NewCircuitManager(2)
+	first := cm.Next()
+	second := cm.Next()
+	if first.ID == second.ID {
+		t.Fatalf("expected different circuits")
+	}
+	third := cm.Next()
+	if third.ID == second.ID {
+		t.Fatalf("rotation failed")
+	}
+}
+
+func TestDNSCache(t *testing.T) {
+	d := newDNSCache(time.Second)
+	addrs1, err := d.LookupHost("localhost")
+	if err != nil || len(addrs1) == 0 {
+		t.Fatalf("lookup failed: %v", err)
+	}
+	addrs2, err := d.LookupHost("localhost")
+	if err != nil {
+		t.Fatalf("lookup2: %v", err)
+	}
+	if &addrs1[0] == &addrs2[0] {
+		t.Fatalf("expected copy of cached slice")
+	}
+}
+
+func TestTorEngineStartStop(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tor")
+	os.WriteFile(script, []byte("#!/bin/sh\nsleep 5"), 0755)
+	os.Setenv("TOR_BINARY", script)
+	defer os.Unsetenv("TOR_BINARY")
+
+	if err := engine.Start(dir); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if engine.cmd == nil {
+		t.Fatal("cmd nil after start")
+	}
+	if err := engine.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if engine.cmd != nil {
+		t.Fatal("cmd not cleared")
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	wm = NewWorkerManager(nil)
+	setConnected(true)
+	setProgress(42)
+	handler := newServer()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics status %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "torwell_connected 1") {
+		t.Fatalf("unexpected metrics: %s", body)
+	}
+}

--- a/backend/network.go
+++ b/backend/network.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	"os/exec"
+	"runtime"
+)
+
+// enableBBRv2 tries to enable the BBRv2 congestion control algorithm on Linux.
+func enableBBRv2() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	// first try bbr2 then fall back to bbr
+	if err := exec.Command("sysctl", "-w", "net.ipv4.tcp_congestion_control=bbr2").Run(); err != nil {
+		if err := exec.Command("sysctl", "-w", "net.ipv4.tcp_congestion_control=bbr").Run(); err != nil {
+			log.Printf("BBR enable failed: %v", err)
+		}
+	}
+}

--- a/backend/state.go
+++ b/backend/state.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// State persists runtime information across restarts.
+type State struct {
+	Connected bool `json:"connected"`
+}
+
+var (
+	state   State
+	stateMu sync.RWMutex
+)
+
+// loadState reads state from disk if present.
+func loadState(dir string) error {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	path := filepath.Join(dir, "state.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			state = State{}
+			return nil
+		}
+		return err
+	}
+	if err := json.Unmarshal(b, &state); err != nil {
+		return err
+	}
+	return nil
+}
+
+// saveState writes the current state to disk.
+func saveState(dir string) error {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "state.json")
+	return os.WriteFile(path, b, 0600)
+}
+
+func setConnected(c bool) {
+	stateMu.Lock()
+	state.Connected = c
+	stateMu.Unlock()
+}
+
+func isConnected() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return state.Connected
+}

--- a/backend/torengine.go
+++ b/backend/torengine.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// TorEngine manages the embedded Tor process.
+type TorEngine struct {
+	mu  sync.Mutex
+	cmd *exec.Cmd
+}
+
+var engine = &TorEngine{}
+
+// Start launches the tor process using a torrc located in dir if present.
+func (t *TorEngine) Start(dir string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cmd != nil {
+		return nil
+	}
+	tor := os.Getenv("TOR_BINARY")
+	if tor == "" {
+		tor = "tor"
+	}
+	args := []string{}
+	torrc := filepath.Join(dir, "torrc")
+	if _, err := os.Stat(torrc); err == nil {
+		args = append(args, "-f", torrc)
+	}
+	// Append OBFS4 bridges if enabled and bridges.txt exists
+	c := getConfig()
+	if c.OBFS4 {
+		bridges := filepath.Join(dir, "bridges.txt")
+		if data, err := os.ReadFile(bridges); err == nil {
+			args = append(args, "--UseBridges", "1", "--ClientTransportPlugin", "obfs4 exec obfs4proxy")
+			scanner := bufio.NewScanner(bytes.NewReader(data))
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				args = append(args, "--Bridge", line)
+			}
+		}
+	}
+	cmd := exec.Command(tor, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	t.cmd = cmd
+	return nil
+}
+
+// Stop terminates the running tor process if started.
+func (t *TorEngine) Stop() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cmd == nil {
+		return nil
+	}
+	err := t.cmd.Process.Kill()
+	t.cmd.Wait()
+	t.cmd = nil
+	return err
+}

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// Worker represents a single Cloudflare Worker HTTPS endpoint.
+type Worker struct {
+	URL    string
+	Active bool
+}
+
+// WorkerManager stores and validates worker endpoints.
+type WorkerManager struct {
+	mu      sync.RWMutex
+	workers []Worker
+	client  *http.Client
+	index   int
+	file    string
+}
+
+// NewWorkerManager creates a manager. If a dnsCache is provided it will be used
+// for HTTP lookups so worker health checks benefit from cached DNS results.
+func NewWorkerManager(dns *dnsCache) *WorkerManager {
+	client := &http.Client{Timeout: 5 * time.Second}
+	if dns != nil {
+		dialer := &net.Dialer{}
+		transport := &http.Transport{}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := dns.LookupHost(host)
+			if err == nil {
+				for _, ip := range ips {
+					conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
+					if err == nil {
+						return conn, nil
+					}
+				}
+			}
+			return dialer.DialContext(ctx, network, addr)
+		}
+		client.Transport = transport
+	}
+	return &WorkerManager{
+		client: client,
+	}
+}
+
+// StartHealthChecker runs a loop that periodically checks worker health.
+func (m *WorkerManager) StartHealthChecker(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.CheckAll()
+			}
+		}
+	}()
+}
+
+// List returns a copy of the configured workers.
+func (m *WorkerManager) List() []Worker {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cp := make([]Worker, len(m.workers))
+	copy(cp, m.workers)
+	return cp
+}
+
+// Next returns the next active worker URL using round robin.
+// The bool indicates whether a worker was found.
+func (m *WorkerManager) Next() (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.workers) == 0 {
+		return "", false
+	}
+	for i := 0; i < len(m.workers); i++ {
+		w := m.workers[m.index%len(m.workers)]
+		m.index = (m.index + 1) % len(m.workers)
+		if w.Active {
+			return w.URL, true
+		}
+	}
+	return "", false
+}
+
+// Add validates and adds a new endpoint.
+func (m *WorkerManager) Add(url string) error {
+	if url == "" {
+		return errors.New("empty url")
+	}
+	if err := m.checkHealth(url); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, w := range m.workers {
+		if w.URL == url {
+			return errors.New("duplicate url")
+		}
+	}
+	m.workers = append(m.workers, Worker{URL: url, Active: true})
+	return m.save()
+}
+
+// Remove deletes a worker endpoint if present.
+func (m *WorkerManager) Remove(url string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, w := range m.workers {
+		if w.URL == url {
+			m.workers = append(m.workers[:i], m.workers[i+1:]...)
+			break
+		}
+	}
+	_ = m.save()
+}
+
+// CheckAll updates the Active status of all workers.
+func (m *WorkerManager) CheckAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, w := range m.workers {
+		if err := m.checkHealth(w.URL); err != nil {
+			m.workers[i].Active = false
+		} else {
+			m.workers[i].Active = true
+		}
+	}
+	_ = m.save()
+}
+
+// Test returns an error if the given worker URL does not respond to the
+// health check.
+func (m *WorkerManager) Test(url string) error {
+	if url == "" {
+		return errors.New("empty url")
+	}
+	return m.checkHealth(url)
+}
+
+// TestAll runs health checks on all configured workers and returns a map with
+// the results. It updates the Active flag and persists the list.
+func (m *WorkerManager) TestAll() map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	results := make(map[string]bool, len(m.workers))
+	for i, w := range m.workers {
+		if err := m.checkHealth(w.URL); err != nil {
+			m.workers[i].Active = false
+			results[w.URL] = false
+		} else {
+			m.workers[i].Active = true
+			results[w.URL] = true
+		}
+	}
+	_ = m.save()
+	return results
+}
+
+// checkHealth performs a simple GET on /.well-known/healthz.
+func (m *WorkerManager) checkHealth(url string) error {
+	resp, err := m.client.Get(url + "/.well-known/healthz")
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("health check failed")
+	}
+	return nil
+}
+
+// Load reads workers from the given file if it exists.
+func (m *WorkerManager) Load(file string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.file = file
+	b, err := os.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return json.Unmarshal(b, &m.workers)
+}
+
+// save persists current workers to the configured file.
+func (m *WorkerManager) save() error {
+	if m.file == "" {
+		return nil
+	}
+	b, err := json.MarshalIndent(m.workers, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.file, b, 0600)
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+(cd backend && make clean all)
+(cd ui && npm install && npm run build)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,1022 @@
+{
+  "name": "torwell84-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "torwell84-ui",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "@playwright/test": "^1.42.1",
+        "@sveltejs/kit": "next",
+        "svelte": "^3.0.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sveltejs/kit": {
+      "version": "1.0.0-next.589",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.589.tgz",
+      "integrity": "sha512-5ABRw46z9B+cCe/YWhcx+I/azNZg1NCDEkVJifZn8ToFoJ3a1eP0OexNIrvMEWpllMbNMPcJm2TC9tnz9oPfWQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.0.0",
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0",
+        "devalue": "^4.2.0",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.27.0",
+        "mime": "^3.0.0",
+        "sade": "^1.8.1",
+        "set-cookie-parser": "^2.5.1",
+        "sirv": "^2.0.2",
+        "tiny-glob": "^0.2.9",
+        "undici": "5.14.0"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "svelte": "^3.54.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.3.tgz",
+      "integrity": "sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
+        "debug": "^4.3.4",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.3",
+        "svelte-hmr": "^0.15.3",
+        "vitefu": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.4.tgz",
+      "integrity": "sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >= 16"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.2.0",
+        "svelte": "^3.54.0 || ^4.0.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/playwright": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
+      "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "3.59.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/svelte-hmr": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
+      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.20 || ^14.13.1 || >= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
+      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+      "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "torwell84-ui",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "svelte-kit dev",
+    "build": "svelte-kit build",
+    "preview": "svelte-kit preview",
+    "tauri": "tauri dev",
+    "mobile:android": "tauri android dev",
+    "mobile:ios": "tauri ios dev",
+    "test": "playwright test",
+    "postinstall": "playwright install --with-deps"
+  },
+  "devDependencies": {
+    "@sveltejs/kit": "next",
+    "svelte": "^3.0.0",
+    "@playwright/test": "^1.42.1",
+    "@tauri-apps/cli": "^2.0.0",
+    "@tauri-apps/api": "^2.0.0"
+  }
+}

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run build && npm run preview',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:4173',
+  },
+});

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,0 +1,17 @@
+html,body{
+  margin:0;
+  padding:0;
+  font-family:system-ui, sans-serif;
+  background:linear-gradient(135deg,#222,#111);
+  color:#fff;
+  -webkit-font-smoothing:antialiased;
+  height:100%;
+}
+
+.glass{
+  backdrop-filter:blur(20px) saturate(150%);
+  background:rgba(255,255,255,0.1);
+  border:1px solid rgba(255,255,255,0.25);
+  box-shadow:0 4px 20px rgba(0,0,0,0.4);
+  border-radius:12px;
+}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,0 +1,4 @@
+<script>
+  import "../app.css";
+</script>
+<slot />

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+let connected = false;
+let progress = 0;
+let showLogs = false;
+let showSettings = false;
+
+const countries = [
+  "Deutschland","Frankreich","Belgien","Schweiz","Liechtenstein",
+  "Luxemburg","\u00D6sterreich","Spanien","Italien","Portugal",
+  "Russland","Rum\u00E4nien","T\u00FCrkei","UK","USA","Kanada",
+  "Mexiko","Brasilien","Argentinien","Japan","China","Antarktis"
+];
+
+let entry = countries[0];
+let middle = countries[1];
+let exit = countries[2];
+interface Worker { URL: string; Active: boolean }
+let workers: Worker[] = [];
+let connectionLogs: string[] = [];
+let systemLogs: string[] = [];
+let obfs4 = true;
+let prewarm = true;
+let newWorker = '';
+let status = '';
+
+$: barColor = progress < 40 ? '#9c27b0' : progress < 80 ? '#2196f3' : '#4caf50';
+
+async function fetchStatus() {
+  const res = await fetch('/status');
+  if (res.ok) {
+    const data = await res.json();
+    connected = data.connected;
+    progress = data.progress;
+    status = data.status || '';
+    workers = data.workers;
+    if (data.config) {
+      obfs4 = data.config.obfs4;
+      prewarm = data.config.prewarm;
+    }
+  }
+}
+
+onMount(() => {
+  fetchStatus();
+  const id = setInterval(fetchStatus, 1000);
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js');
+  }
+  return () => clearInterval(id);
+});
+
+async function connect() {
+  await fetch('/connect', { method: 'POST' });
+  connected = true;
+}
+
+async function disconnect() {
+  await fetch('/disconnect', { method: 'POST' });
+  connected = false;
+}
+
+async function newCircuit() {
+  await fetch('/new-circuit', { method: 'POST' });
+}
+
+async function newIdentity() {
+  await fetch('/new-identity', { method: 'POST' });
+}
+
+async function loadLogs() {
+  connectionLogs = await fetch('/logs/connection').then((r) => r.json());
+  systemLogs = await fetch('/logs/general').then((r) => r.json());
+}
+
+async function uploadTorrc(files: FileList | null) {
+  if (!files || !files[0]) return;
+  const form = new FormData();
+  form.append('file', files[0]);
+  await fetch('/torrc', { method: 'POST', body: form });
+}
+
+async function saveConfig() {
+  await fetch('/config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ obfs4, prewarm })
+  });
+}
+
+async function addWorker() {
+  if (!newWorker) return;
+  const res = await fetch('/workers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ URL: newWorker })
+  });
+  if (res.ok) {
+    newWorker = '';
+    await fetchStatus();
+  }
+}
+
+async function testWorker(url: string) {
+  const res = await fetch('/workers/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ URL: url })
+  });
+  if (res.ok) {
+    await fetchStatus();
+  }
+}
+
+async function testAllWorkers() {
+  const res = await fetch('/workers/test', { method: 'POST' });
+  if (res.ok) {
+    await fetchStatus();
+  }
+}
+
+async function removeWorker(url: string) {
+  const res = await fetch('/workers', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ URL: url })
+  });
+  if (res.ok) {
+    await fetchStatus();
+  }
+}
+</script>
+
+<style>
+.progress {
+  height: 6px;
+  margin-bottom: 10px;
+  overflow: hidden;
+  border-radius: 3px;
+}
+.bar {
+  height: 100%;
+  background: var(--bar-color);
+  transition: width 0.3s ease;
+  will-change: width, transform;
+  transform: translateZ(0);
+}
+.chain {
+  display: flex;
+  justify-content: space-around;
+  margin: 20px 0;
+}
+.node {
+  text-align: center;
+  padding: 10px;
+  min-width: 70px;
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+.node.glass:hover {
+  transform: scale(1.05);
+}
+.buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  padding: 20px;
+  min-width: 300px;
+  max-height: 80vh;
+  overflow: auto;
+}
+</style>
+
+<div class="progress glass">
+    <div class="bar" style="width:{progress}%; --bar-color:{barColor}"></div>
+<div>{status}</div>
+</div>
+
+<div class="chain">
+  <div class="node glass">
+    <div>U</div>
+    <div>You</div>
+  </div>
+  <div class="node glass">
+    <select bind:value={entry}>
+      {#each countries as c}
+        <option>{c}</option>
+      {/each}
+    </select>
+    <div>Entry</div>
+  </div>
+  <div class="node glass">
+    <select bind:value={middle}>
+      {#each countries as c}
+        <option>{c}</option>
+      {/each}
+    </select>
+    <div>Middle</div>
+  </div>
+  <div class="node glass">
+    <select bind:value={exit}>
+      {#each countries as c}
+        <option>{c}</option>
+      {/each}
+    </select>
+    <div>Exit</div>
+  </div>
+  <div class="node glass" style="opacity:{workers.some(w => w.Active) ? 1 : 0.3}">
+    <div>CF</div>
+    <div>Worker</div>
+  </div>
+</div>
+
+<div class="buttons">
+  {#if connected}
+    <button on:click={disconnect}>Disconnect</button>
+    <button on:click={newCircuit}>New Circuit</button>
+    <button on:click={newIdentity}>New Identity</button>
+  {:else}
+    <button on:click={connect}>Connect</button>
+  {/if}
+  <button on:click={() => { loadLogs(); showLogs = true; }}>Logs</button>
+  <button on:click={() => (showSettings = true)}>Settings</button>
+</div>
+
+{#if showLogs}
+  <div class="modal" on:click={() => (showLogs = false)}>
+    <div class="modal-content glass" on:click|stopPropagation>
+      <h2>Logs</h2>
+      <h3>Connection</h3>
+      <ul>{#each connectionLogs as l}<li>{l}</li>{/each}</ul>
+      <h3>System</h3>
+      <ul>{#each systemLogs as l}<li>{l}</li>{/each}</ul>
+      <button on:click={() => { connectionLogs = []; systemLogs = []; }}>Clear</button>
+      <button on:click={() => (showLogs = false)}>Close</button>
+    </div>
+  </div>
+{/if}
+
+{#if showSettings}
+  <div class="modal" on:click={() => (showSettings = false)}>
+    <div class="modal-content glass" on:click|stopPropagation>
+      <h2>Settings</h2>
+      <label><input type="checkbox" bind:checked={obfs4} on:change={saveConfig}> OBFS4</label>
+      <label><input type="checkbox" bind:checked={prewarm} on:change={saveConfig}> Circuit Pre-Warm</label>
+      <div>
+        <label>torrc upload <input type="file" on:change={(e) => uploadTorrc(e.target.files)}></label>
+      </div>
+      <div>
+        <h3>Cloudflare Workers</h3>
+        <ul>
+          {#each workers as w}
+            <li>{w.URL} {#if !w.Active}(inactive){/if}
+              <button on:click={() => testWorker(w.URL)}>Test</button>
+              <button on:click={() => removeWorker(w.URL)}>Remove</button>
+            </li>
+          {/each}
+        </ul>
+        <input bind:value={newWorker} placeholder="https://example.workers.dev" />
+        <button on:click={addWorker}>Add</button>
+        <button on:click={testAllWorkers}>Test All</button>
+      </div>
+      <button on:click={() => (showSettings = false)}>Close</button>
+    </div>
+  </div>
+{/if}

--- a/ui/static/manifest.json
+++ b/ui/static/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Torwell84",
+  "short_name": "Torwell84",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "description": "Cross-platform Tor VPN client",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/ui/static/service-worker.js
+++ b/ui/static/service-worker.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('torwell-cache').then(cache => cache.add('/'))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(r => r || fetch(event.request))
+  );
+});

--- a/ui/tauri.conf.json
+++ b/ui/tauri.conf.json
@@ -1,0 +1,18 @@
+{
+  "package": {
+    "productName": "Torwell84",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeBuildCommand": "npm run build",
+    "devPath": "http://localhost:5173",
+    "distDir": "build"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "Torwell84"
+      }
+    ]
+  }
+}

--- a/ui/tauri.mobile.conf.json
+++ b/ui/tauri.mobile.conf.json
@@ -1,0 +1,21 @@
+{
+  "package": {
+    "productName": "Torwell84",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeBuildCommand": "npm run build",
+    "distDir": "build"
+  },
+  "tauri": {
+    "mobile": {
+      "android": {
+        "packageId": "com.example.torwell84",
+        "targets": ["aarch64"]
+      },
+      "ios": {
+        "bundleIdentifier": "com.example.torwell84"
+      }
+    }
+  }
+}

--- a/ui/tests/basic.spec.ts
+++ b/ui/tests/basic.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('open settings modal', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: /connect/i })).toBeVisible();
+  await page.getByRole('button', { name: /settings/i }).click();
+  await expect(page.locator('h2', { hasText: 'Settings' })).toBeVisible();
+  await page.getByRole('button', { name: /close/i }).click();
+  await expect(page.locator('h2', { hasText: 'Settings' })).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- implement `/workers/test` endpoint
- expose worker testing buttons in the Svelte UI
- update docs with the new API and UI behaviour
- extend unit tests for worker testing

## Testing
- `cd backend && gofmt -w *.go main_test.go torengine.go config.go circuit.go dnscache.go log.go network.go worker.go state.go main.go >/tmp/gofmt.log && tail -n 20 /tmp/gofmt.log`
- `go test ./... > /tmp/go_test.log && tail -n 20 /tmp/go_test.log`
- `cd ui && npm test >/tmp/pw_test.log && tail -n 20 /tmp/pw_test.log`

------
https://chatgpt.com/codex/tasks/task_e_684c874c0e4c8333a4856060e178b925